### PR TITLE
fix: build error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,9 +47,8 @@ jobs:
       - name: Build image
         uses: docker/build-push-action@v6
         with:
-          push: ${{ github.ref == 'refs/heads/master' }}
+          push: true
           platforms: linux/amd64,linux/arm64
-          load: true
           context: .
           file: ./Dockerfile
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.app_name }}:${{ env.app_version }}


### PR DESCRIPTION
closes #6 

ERROR: docker exporter does not currently support exporting manifest lists